### PR TITLE
Fix equality operators in canopy change script

### DIFF
--- a/scripts/Change Data Capture.py
+++ b/scripts/Change Data Capture.py
@@ -25,7 +25,7 @@ else:
         'BAND_A': 1,
         'INPUT_B': raster_2022_layer.source(),
         'BAND_B': 1,
-        'FORMULA': '(A=1)*(B=0)',
+        'FORMULA': '(A==1)*(B==0)',
         'NO_DATA': -9999,
         'RTYPE': 5,
         'OUTPUT': output_loss_path
@@ -39,7 +39,7 @@ else:
         'BAND_A': 1,
         'INPUT_B': raster_2022_layer.source(),
         'BAND_B': 1,
-        'FORMULA': '(A=0)*(B=1)',
+        'FORMULA': '(A==0)*(B==1)',
         'NO_DATA': -9999,
         'RTYPE': 5,
         'OUTPUT': output_gain_path


### PR DESCRIPTION
## Summary
- Correct raster calculator formulas to use `==` for comparisons

## Testing
- `python -m py_compile scripts/Change\ Data\ Capture.py`


------
https://chatgpt.com/codex/tasks/task_e_68989d4d005c832cbbec608e5446cfff